### PR TITLE
MM-679: Enhance Gytheio Content Handler with putFile option (for S3 use multi-part upload)

### DIFF
--- a/gytheio-commons/src/main/java/org/gytheio/content/handler/ContentReferenceHandler.java
+++ b/gytheio-commons/src/main/java/org/gytheio/content/handler/ContentReferenceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2018 Alfresco Software Limited.
  *
  * This file is part of Gytheio
  *
@@ -18,6 +18,7 @@
  */
 package org.gytheio.content.handler;
 
+import java.io.File;
 import java.io.InputStream;
 
 import org.gytheio.content.ContentIOException;
@@ -79,7 +80,18 @@ public interface ContentReferenceHandler
      * @throws ContentIOException
      */
     public long putInputStream(InputStream sourceInputStream, ContentReference targetContentReference) throws ContentIOException;
-    
+
+    /**
+     * Writes the given source file into the given target content reference.
+     * <p>
+     * 
+     * @param sourceFile
+     * @param targetContentReference
+     * @return the size copied
+     * @throws ContentIOException
+     */
+    public long putFile(File sourceFile, ContentReference targetContentReference) throws ContentIOException;
+
     /**
      * Deletes the given content reference
      * @param contentReference

--- a/gytheio-commons/src/main/java/org/gytheio/content/handler/ContentReferenceHandler.java
+++ b/gytheio-commons/src/main/java/org/gytheio/content/handler/ContentReferenceHandler.java
@@ -83,7 +83,6 @@ public interface ContentReferenceHandler
 
     /**
      * Writes the given source file into the given target content reference.
-     * <p>
      * 
      * @param sourceFile
      * @param targetContentReference

--- a/gytheio-commons/src/main/java/org/gytheio/content/handler/FileContentReferenceHandlerImpl.java
+++ b/gytheio-commons/src/main/java/org/gytheio/content/handler/FileContentReferenceHandlerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2018 Alfresco Software Limited.
  *
  * This file is part of Gytheio
  *
@@ -253,6 +253,41 @@ public class FileContentReferenceHandlerImpl implements FileContentReferenceHand
                 catch (IOException e)
                 {
                 }
+            }
+        }
+    }
+
+    @Override
+    public long putFile(File sourceFile, ContentReference targetContentReference)
+            throws ContentIOException
+    {
+        FileOutputStream fileOutputStream = null;
+        FileInputStream fileInputStream = null;
+        try
+        {
+            File targetFile = getFile(targetContentReference, false);
+            fileOutputStream = new FileOutputStream(targetFile);
+            fileInputStream = new FileInputStream(sourceFile);
+            return IOUtils.copyLarge(fileInputStream, fileOutputStream);
+        }
+        catch (IOException e)
+        {
+            throw new ContentIOException("Error copying input stream", e);
+        }
+        catch (InterruptedException e)
+        {
+            return 0;
+        }
+        finally
+        {
+            try
+            {
+                if (fileOutputStream != null) { fileOutputStream.close(); }
+                if (fileInputStream != null) { fileInputStream.close(); }
+            }
+            catch (IOException e)
+            {
+                // Ignore
             }
         }
     }

--- a/gytheio-content-handlers/gytheio-content-handler-s3/src/main/java/org/gytheio/content/handler/s3/S3ContentReferenceHandlerImpl.java
+++ b/gytheio-content-handlers/gytheio-content-handler-s3/src/main/java/org/gytheio/content/handler/s3/S3ContentReferenceHandlerImpl.java
@@ -319,6 +319,11 @@ public class S3ContentReferenceHandlerImpl extends AbstractUrlContentReferenceHa
             }
             catch (InterruptedException e)
             {
+                logger.error("Upload was interrupted: "+e.getMessage());
+
+                // Be a good citizen  and set interrupt flag
+                Thread.currentThread().interrupt();
+
                 throw new ContentIOException("Failed to write content", e);
             }
 

--- a/gytheio-content-handlers/gytheio-content-handler-s3/src/main/java/org/gytheio/content/handler/s3/S3ContentReferenceHandlerImpl.java
+++ b/gytheio-content-handlers/gytheio-content-handler-s3/src/main/java/org/gytheio/content/handler/s3/S3ContentReferenceHandlerImpl.java
@@ -310,7 +310,7 @@ public class S3ContentReferenceHandlerImpl extends AbstractUrlContentReferenceHa
 
         try
         {
-            Long contentLength = sourceFile.length();
+            long contentLength = sourceFile.length();
 
             try
             {
@@ -334,7 +334,7 @@ public class S3ContentReferenceHandlerImpl extends AbstractUrlContentReferenceHa
 
             if (logger.isWarnEnabled())
             {
-                if ((contentLength != null) && (storedContentLength != contentLength))
+                if (storedContentLength != contentLength)
                 {
                     logger.warn("Metadata length differs - expected " + contentLength + ", actual "+ storedContentLength);
                 }

--- a/gytheio-content-handlers/gytheio-content-handler-s3/src/test/java/org/gytheio/content/handler/s3/S3ContentReferenceHandlerImplTest.java
+++ b/gytheio-content-handlers/gytheio-content-handler-s3/src/test/java/org/gytheio/content/handler/s3/S3ContentReferenceHandlerImplTest.java
@@ -235,7 +235,7 @@ public class S3ContentReferenceHandlerImplTest
     public void testPutFile() throws IOException
     {
         String envVar;
-        
+
         envVar = getVar("pf_start_size");
         long pf_start_size = (envVar != null ? new Long(envVar) : 1024 * 1024 * 1L); // default 1 MiB
 
@@ -247,7 +247,7 @@ public class S3ContentReferenceHandlerImplTest
 
         envVar = getVar("pf_repeat");
         int pf_repeat = (envVar != null ? new Integer(envVar) : 1);
-        
+
         if (logger.isInfoEnabled())
         {
             logger.info("testPutFile: pf_start_size="+pf_start_size+", pf_multiplier="+pf_multiplier
@@ -255,11 +255,9 @@ public class S3ContentReferenceHandlerImplTest
         }
 
         long testContentSizeInBytes = pf_start_size;
-        
+
         for (int i = 0; i < pf_count; i++)
         {
-            testContentSizeInBytes = testContentSizeInBytes * pf_multiplier;
-
             File testFile = createTestFile(testContentSizeInBytes);
 
             for (int j = 0; j < pf_repeat; j++)
@@ -275,6 +273,9 @@ public class S3ContentReferenceHandlerImplTest
             {
                 testFile.delete();
             }
+
+            // increase test file size for next loop
+            testContentSizeInBytes = testContentSizeInBytes * pf_multiplier;
         }
     }
 

--- a/gytheio-content-handlers/gytheio-content-handler-webdav/src/main/java/org/gytheio/content/handler/webdav/WebDavContentReferenceHandlerImpl.java
+++ b/gytheio-content-handlers/gytheio-content-handler-webdav/src/main/java/org/gytheio/content/handler/webdav/WebDavContentReferenceHandlerImpl.java
@@ -195,6 +195,10 @@ public class WebDavContentReferenceHandlerImpl extends AbstractUrlContentReferen
     public long putFile(File sourceFile, ContentReference targetContentReference)
             throws ContentIOException
     {
+        if (!isContentReferenceSupported(targetContentReference))
+        {
+            throw new ContentIOException("ContentReference not supported");
+        }
         try
         {
             FileInputStream fis = new FileInputStream(sourceFile);

--- a/gytheio-content-handlers/gytheio-content-handler-webdav/src/main/java/org/gytheio/content/handler/webdav/WebDavContentReferenceHandlerImpl.java
+++ b/gytheio-content-handlers/gytheio-content-handler-webdav/src/main/java/org/gytheio/content/handler/webdav/WebDavContentReferenceHandlerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2018 Alfresco Software Limited.
  *
  * This file is part of Gytheio
  *
@@ -18,6 +18,8 @@
  */
 package org.gytheio.content.handler.webdav;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -186,6 +188,32 @@ public class WebDavContentReferenceHandlerImpl extends AbstractUrlContentReferen
         catch (IOException e)
         {
             throw new ContentIOException("Failed to read content: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public long putFile(File sourceFile, ContentReference targetContentReference)
+            throws ContentIOException
+    {
+        try
+        {
+            FileInputStream fis = new FileInputStream(sourceFile);
+            try
+            {
+                return putInputStream(fis, targetContentReference);
+            } 
+            finally
+            {
+                if (fis != null)
+                {
+                    fis.close();
+                }
+            }
+        }
+        catch (IOException e)
+        {
+            logger.error(e.getMessage(), e);
+            throw new ContentIOException("Failed to write content: " + e.getMessage(), e);
         }
     }
 

--- a/gytheio-transform/gytheio-transform-commons/src/main/java/org/gytheio/content/transform/AbstractFileContentTransformerWorker.java
+++ b/gytheio-transform/gytheio-transform-commons/src/main/java/org/gytheio/content/transform/AbstractFileContentTransformerWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2018 Alfresco Software Limited.
  *
  * This file is part of Gytheio
  *
@@ -187,8 +187,7 @@ public abstract class AbstractFileContentTransformerWorker extends AbstractConte
                             resultFile.getName(), resultMediaType);
                 }
                 target.setSize(resultFile.length());
-                FileInputStream targetInputStream = new FileInputStream(resultFile);
-                targetContentReferenceHandler.putInputStream(targetInputStream, target);
+                targetContentReferenceHandler.putFile(resultFile, target);
             }
             else
             {

--- a/gytheio-transform/gytheio-transform-commons/src/test/java/org/gytheio/content/transform/MockUrlContentReferenceHandlerContentTransformerWorkerTest.java
+++ b/gytheio-transform/gytheio-transform-commons/src/test/java/org/gytheio/content/transform/MockUrlContentReferenceHandlerContentTransformerWorkerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2018 Alfresco Software Limited.
  *
  * This file is part of Gytheio
  *
@@ -150,6 +150,17 @@ public class MockUrlContentReferenceHandlerContentTransformerWorkerTest extends 
                 throw new IllegalArgumentException(EXCEPTION_MESSAGE_NULL_SIZE);
             }
             return delegateContentReferenceHandler.putInputStream(sourceInputStream, targetContentReference);
+        }
+
+        @Override
+        public long putFile(File sourceFile, ContentReference targetContentReference)
+                throws ContentIOException
+        {
+            if (targetContentReference.getSize() == null)
+            {
+                throw new IllegalArgumentException(EXCEPTION_MESSAGE_NULL_SIZE);
+            }
+            return delegateContentReferenceHandler.putFile(sourceFile, targetContentReference);
         }
 
         @Override


### PR DESCRIPTION
- adds "putFile" interface (in addition to existing "putInputStream")
- S3 impl of "putFile" uses S3 TransferManager upload (multi-part / parallel, when applicable)
- new test method ("testPutFile") with some basic options to override (eg. when running on a remote EC2 + S3)