### PR TITLE
MM-773 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
         <maven.scm.url>https://github.com/Alfresco/gytheio</maven.scm.url>
         <maven.distributionManagement.snapshot.url>https://artifacts.alfresco.com/nexus/content/repositories/snapshots</maven.distributionManagement.snapshot.url>
         <maven.distributionManagement.url>https://artifacts.alfresco.com/nexus/content/repositories/thirdparty</maven.distributionManagement.url>
-        <maven.compile.source>11</maven.compile.source>
-        <maven.compile.target>11</maven.compile.target>
+        <maven.compile.source>1.8</maven.compile.source>
+        <maven.compile.target>1.8</maven.compile.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         


### PR DESCRIPTION
As per @killerboot request and backwards compatibility desire we're setting the `maven.compiler.source` and `maven.compiler.target` back to `1.8` 