### PR TITLE
MM-861: Security Scan - Transitive - commons-codec-1.9 (-> 1.14)

### DIFF
--- a/gytheio-content-handlers/gytheio-content-handler-s3/pom.xml
+++ b/gytheio-content-handlers/gytheio-content-handler-s3/pom.xml
@@ -72,14 +72,21 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.10</version>
+            <version>${dependency.http-client.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.13</version>
+            <version>${dependency.http-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${dependency.commons-codec.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/gytheio-content-handlers/gytheio-content-handler-webdav/pom.xml
+++ b/gytheio-content-handlers/gytheio-content-handler-webdav/pom.xml
@@ -26,15 +26,21 @@
             <artifactId>sardine</artifactId>
             <version>${dependency.sardine.version}</version>
             <exclusions>
+
                 <!-- MM-851 - override Sardine 5.9 (Jul 2019) -->
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>commons-codec</groupId>
                     <artifactId>commons-codec</artifactId>
                 </exclusion>
+
             </exclusions>
         </dependency>
 
@@ -44,19 +50,15 @@
             <artifactId>httpclient</artifactId>
             <version>${dependency.http-client.version}</version>
         </dependency>
-
-        <!-- MM-851 - override Sardine 5.9 (Jul 2019) -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
             <version>${dependency.http-core.version}</version>
         </dependency>
-
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>${dependency.commons-codec.version}</version>
-            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/gytheio-content-handlers/gytheio-content-handler-webdav/pom.xml
+++ b/gytheio-content-handlers/gytheio-content-handler-webdav/pom.xml
@@ -20,11 +20,45 @@
             <artifactId>gytheio-commons</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>com.github.lookfirst</groupId>
             <artifactId>sardine</artifactId>
             <version>${dependency.sardine.version}</version>
+            <exclusions>
+                <!-- MM-851 - override Sardine 5.9 (Jul 2019) -->
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
+        <!-- MM-851 - override Sardine 5.9 (Jul 2019) -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${dependency.http-client.version}</version>
+        </dependency>
+
+        <!-- MM-851 - override Sardine 5.9 (Jul 2019) -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>${dependency.http-core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${dependency.commons-codec.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/gytheio-content-handlers/pom.xml
+++ b/gytheio-content-handlers/pom.xml
@@ -10,7 +10,13 @@
 
     <artifactId>gytheio-content-handlers</artifactId>
     <packaging>pom</packaging>
-    
+
+    <properties>
+        <dependency.http-client.version>4.5.12</dependency.http-client.version>
+        <dependency.http-core.version>4.4.13</dependency.http-core.version>
+        <dependency.commons-codec.version>1.14</dependency.commons-codec.version>
+    </properties>
+
     <modules>
         <module>gytheio-content-handler-s3</module>
         <module>gytheio-content-handler-webdav</module>


### PR DESCRIPTION
- commons-codec-1.9 (via sardine 5.9 -> http-client-4.5.1 / http-core-4.4.3)
- commons-codec-1.11 (via http-client-4.5.12 / http-core-4.4.13)

- update to match ACS Packaging master (@ 951831e )
-- http-client-4.5.12
-- http-core-4.4.13
-- commons-codec-1.14