### PR TITLE
Features/apps 691 introduce sourceclear agent scan for veracode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ jobs:
       stage: build
       script: bash _ci/build.sh
 
-    - name: "WhiteSource"
-      script: bash _ci/whitesource.sh
+#    - name: "WhiteSource"
+#      script: bash _ci/whitesource.sh
     
     - name: "Source Clear Scan (SCA)"  
       before_install: bash _ci/init.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ branches:
     - master
     - /^SP\/.+$/
     - /^HF\/.+$/
+    - /^features\/.+$/
 
 stages:
   - build
@@ -33,6 +34,11 @@ jobs:
 
     - name: "WhiteSource"
       script: bash _ci/whitesource.sh
+    
+    - name: "Source Clear Scan (SCA)"  
+      before_install: bash _ci/init.sh
+      # Run Veracode
+      script: travis_wait 30 bash _ci/source_clear.sh
 
     - name: "Release"
       stage: release

--- a/_ci/source_clear.sh
+++ b/_ci/source_clear.sh
@@ -9,7 +9,7 @@ mvn -B -q clean install \
     -DskipTests \
     -Dmaven.javadoc.skip=true \
     com.srcclr:srcclr-maven-plugin:scan \
-    -Dcom.srcclr.apiToken=$SRCCLR_API_TOKEN > scan.log
+    -Dcom.srcclr.apiToken=${SRCCLR_API_TOKEN} > scan.log
 
 SUCCESS=$?   # this will read exit code of the previous command
 

--- a/_ci/source_clear.sh
+++ b/_ci/source_clear.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+echo "=========================== Starting SourceClear Script ==========================="
+PS4="\[\e[35m\]+ \[\e[m\]"
+set +e -v -x
+pushd "$(dirname "${BASH_SOURCE[0]}")/../"
+
+mvn -B -q clean install \
+    -DskipTests \
+    -Dmaven.javadoc.skip=true \
+    com.srcclr:srcclr-maven-plugin:scan \
+    -Dcom.srcclr.apiToken=$SRCCLR_API_TOKEN > scan.log
+
+SUCCESS=$?   # this will read exit code of the previous command
+
+cat scan.log | grep -e 'Full Report Details' -e 'Failed'
+
+popd
+set +vex
+echo "=========================== Finishing SourceClear Script =========================="
+
+exit ${SUCCESS}

--- a/_ci/whitesource.sh
+++ b/_ci/whitesource.sh
@@ -13,7 +13,7 @@ mvn -B clean install \
     -Dorg.whitesource.checkPolicies=true \
     -Dorg.whitesource.forceCheckAllDependencies=true \
     -Dorg.whitesource.ignorePomModules=false \
-    "-Dorg.whitesource.product=Gytheio" \
+    "-Dorg.whitesource.product=Media Management" \
     -Dmaven.wagon.http.pool=false
 
 

--- a/_ci/whitesource.sh
+++ b/_ci/whitesource.sh
@@ -13,7 +13,7 @@ mvn -B clean install \
     -Dorg.whitesource.checkPolicies=true \
     -Dorg.whitesource.forceCheckAllDependencies=true \
     -Dorg.whitesource.ignorePomModules=false \
-    "-Dorg.whitesource.product=Media Management" \
+    "-Dorg.whitesource.product=Gytheio" \
     -Dmaven.wagon.http.pool=false
 
 


### PR DESCRIPTION
This PR introduces a new stage into Gytheio pipeline asking Veracode to execute a static evaluation of libs and licences.
It is not blocking in case of failure, a solution to this is in progress on security side.
The security scan executed shown no issues on Gytheio.